### PR TITLE
Added parenthesis for vector calculations

### DIFF
--- a/Sledge.Formats/Precision/Polygon.cs
+++ b/Sledge.Formats/Precision/Polygon.cs
@@ -38,10 +38,10 @@ namespace Sledge.Formats.Precision
 
             var verts = new List<Vector3>
             {
-                plane.PointOnPlane + right + up, // Top right
-                plane.PointOnPlane - right + up, // Top left
-                plane.PointOnPlane - right - up, // Bottom left
-                plane.PointOnPlane + right - up, // Bottom right
+                (plane.PointOnPlane + right) + up, // Top right
+                (plane.PointOnPlane - right) + up, // Top left
+                (plane.PointOnPlane - right) - up, // Bottom left
+                (plane.PointOnPlane + right) - up, // Bottom right
             };
             
             var origin = verts.Aggregate(Vector3.Zero, (x, y) => x + y) / verts.Count;


### PR DESCRIPTION
Just a small cosmetic change. Since there is two subtraction operations side by side, I thought it might useful to clarify the order of the vector operations. It might prevent bugs when this code is being used as a reference for other language implementations as the operator precedence behavior might vary.