### PR TITLE
Add default constructors to supported wad lumps

### DIFF
--- a/Sledge.Formats.Texture/Wad/Lumps/FontLump.cs
+++ b/Sledge.Formats.Texture/Wad/Lumps/FontLump.cs
@@ -18,6 +18,10 @@ namespace Sledge.Formats.Texture.Wad.Lumps
         public byte[] ImageData { get; set; }
         public byte[] Palette { get; set; }
 
+        public FontLump()
+        {
+        }
+
         public FontLump(BinaryReader br)
         {
             Width = br.ReadInt32();

--- a/Sledge.Formats.Texture/Wad/Lumps/ImageLump.cs
+++ b/Sledge.Formats.Texture/Wad/Lumps/ImageLump.cs
@@ -9,6 +9,10 @@ namespace Sledge.Formats.Texture.Wad.Lumps
         public int Height { get; set; }
         public byte[] ImageData { get; set; }
 
+        public ImageLump()
+        {
+        }
+
         public ImageLump(BinaryReader br)
         {
             Width = br.ReadInt32();

--- a/Sledge.Formats.Texture/Wad/Lumps/MipTextureLump.cs
+++ b/Sledge.Formats.Texture/Wad/Lumps/MipTextureLump.cs
@@ -6,6 +6,10 @@ namespace Sledge.Formats.Texture.Wad.Lumps
     {
         public override LumpType Type => LumpType.MipTexture;
 
+        public MipTextureLump()
+        {
+        }
+
         public MipTextureLump(BinaryReader br) : base(br, true)
         {
             //

--- a/Sledge.Formats.Texture/Wad/Lumps/PaletteLump.cs
+++ b/Sledge.Formats.Texture/Wad/Lumps/PaletteLump.cs
@@ -8,6 +8,10 @@ namespace Sledge.Formats.Texture.Wad.Lumps
         public byte[] PaletteData { get; set; }
         const int Length = 256 * 3;
 
+        public PaletteLump()
+        {
+        }
+
         public PaletteLump(BinaryReader br)
         {
             PaletteData = br.ReadBytes(Length);

--- a/Sledge.Formats.Texture/Wad/Lumps/QuakeConcharsLump.cs
+++ b/Sledge.Formats.Texture/Wad/Lumps/QuakeConcharsLump.cs
@@ -9,6 +9,10 @@ namespace Sledge.Formats.Texture.Wad.Lumps
         public int Height { get; set; }
         public byte[] ImageData { get; set; }
 
+        public QuakeConcharsLump()
+        {
+        }
+
         public QuakeConcharsLump(BinaryReader br)
         {
             Width = 128;

--- a/Sledge.Formats.Texture/Wad/Lumps/RawTextureLump.cs
+++ b/Sledge.Formats.Texture/Wad/Lumps/RawTextureLump.cs
@@ -6,6 +6,10 @@ namespace Sledge.Formats.Texture.Wad.Lumps
     {
         public virtual LumpType Type => LumpType.RawTexture;
 
+        public RawTextureLump()
+        {
+        }
+
         public RawTextureLump(BinaryReader br) : this(br, false)
         {
             //


### PR DESCRIPTION
This PR adds default constructors to wad lumps that are supported by this library to allow users to construct lump objects and initialize them with data for writing.

Resolves LogicAndTrick/sledge-formats#9