### PR TITLE
Clamp lightmap size to prevent buffer over-read

### DIFF
--- a/Sledge.Formats.Bsp/Sledge.Formats.Bsp.csproj
+++ b/Sledge.Formats.Bsp/Sledge.Formats.Bsp.csproj
@@ -11,8 +11,8 @@
     <RepositoryUrl>https://github.com/LogicAndTrick/sledge-formats</RepositoryUrl>
     <RepositoryType>Git</RepositoryType>
     <PackageTags>half-life quake valve bsp</PackageTags>
-    <PackageReleaseNotes>Add empty constructor for BspFile</PackageReleaseNotes>
-    <Version>1.0.6</Version>
+    <PackageReleaseNotes>Bugfix for oversized lightmaps</PackageReleaseNotes>
+    <Version>1.0.7</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">


### PR DESCRIPTION
This clamps the size of the lightmap data array in case the lightmap data is being read from the end of the BSP file lightmap data array.

I've tried to adjust the lightmap width and height accordingly but it's a guessing game at best. The problem is that lightmaps are being stored as `Lightmap` objects as textures with integer width and height, whereas actual lightmaps are subrects with fractional width and height in a larger image.

It may be necessary to change how lightmaps are converted to account for this.

See SamVanheer/HalfLife.UnifiedSdk.MapDecompiler#21