### PR TITLE
Add Null contents type

### DIFF
--- a/Sledge.Formats.Bsp/Objects/Contents.cs
+++ b/Sledge.Formats.Bsp/Objects/Contents.cs
@@ -16,6 +16,7 @@
         Current270 = -12,
         CurrentUp = -13,
         CurrentDown = -14,
-        Translucent = -15
+        Translucent = -15,
+        Null = -17
     }
 }

--- a/Sledge.Formats.Bsp/Sledge.Formats.Bsp.csproj
+++ b/Sledge.Formats.Bsp/Sledge.Formats.Bsp.csproj
@@ -11,8 +11,8 @@
     <RepositoryUrl>https://github.com/LogicAndTrick/sledge-formats</RepositoryUrl>
     <RepositoryType>Git</RepositoryType>
     <PackageTags>half-life quake valve bsp</PackageTags>
-    <PackageReleaseNotes>Bugfix for oversized lightmaps</PackageReleaseNotes>
-    <Version>1.0.7</Version>
+    <PackageReleaseNotes>Add field for null content type</PackageReleaseNotes>
+    <Version>1.0.8</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">


### PR DESCRIPTION
This add `CONTENTS_NULL` from the compiler: https://github.com/SamVanheer/VHLT-clean/blob/1dd2c2f2dbec06a66acf1b417756f671e055dc48/src/zhlt-vluzacn/common/bspfile.h#L224

Although this content type is supposed to be converted to `CONTENTS_SOLID` during compilation some Day of Defeat maps still have it indicating that some older compilers didn't strip it out.

Affected maps:
* dod_donner
* dod_flugplatz
* dod_glider
* dod_jagd
* dod_merderet
* dod_switch