### PR TITLE
Ensure wad lumps are aligned to 4 byte boundaries, write padding bytes with zero value to match qlumpy

### DIFF
--- a/Sledge.Formats.Texture/Sledge.Formats.Texture.csproj
+++ b/Sledge.Formats.Texture/Sledge.Formats.Texture.csproj
@@ -11,8 +11,8 @@
     <RepositoryUrl>https://github.com/LogicAndTrick/sledge-formats</RepositoryUrl>
     <RepositoryType>Git</RepositoryType>
     <PackageTags>half-life quake source valve wad vtf</PackageTags>
-    <PackageReleaseNotes>Included XML documentation</PackageReleaseNotes>
-    <Version>1.0.2</Version>
+    <PackageReleaseNotes>Fix bug/incompatibility with Wally when saving a wad file</PackageReleaseNotes>
+    <Version>1.0.3</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/Sledge.Formats.Texture/Wad/Entry.cs
+++ b/Sledge.Formats.Texture/Wad/Entry.cs
@@ -39,7 +39,7 @@ namespace Sledge.Formats.Texture.Wad
             bw.Write((int) UncompressedSize);
             bw.Write((byte) Type);
             bw.Write((byte) (Compression ? 1 : 0));
-            bw.Write((short) 2);
+            bw.Write((short) 0);
             bw.WriteFixedLengthString(Encoding.ASCII, NameLength, Name);
             return (int)(bw.BaseStream.Position - pos);
         }

--- a/Sledge.Formats.Texture/Wad/WadFile.cs
+++ b/Sledge.Formats.Texture/Wad/WadFile.cs
@@ -75,6 +75,20 @@ namespace Sledge.Formats.Texture.Wad
                 {
                     var pos = bw.BaseStream.Position - startPos;
                     var size = kv.Value.Write(bw);
+
+                    // Align the lump to a 4 byte boundary. This matches QLumpy's behavior and
+                    // avoids a bug in Wally that causes it to load palettes incorrectly.
+                    var paddingCount = (int)(bw.BaseStream.Position & 3);
+
+                    if (paddingCount != 0)
+                    {
+                        size += paddingCount;
+                        for (var padding = paddingCount; padding > 0; --padding)
+                        {
+                            bw.Write((byte)0);
+                        }
+                    }
+
                     var e = kv.Key;
                     e.Offset = (int) pos;
                     e.UncompressedSize = e.CompressedSize = size;


### PR DESCRIPTION
This pads lumps to a 4 byte boundary like qlumpy does and sets the padding bytes to 0.

Resolves #20