### PR TITLE
[Fixes #22] QuakeMapFormat: Correctly handle face texture names composed of multiple tokens

### DIFF
--- a/Sledge.Formats.Map/Formats/QuakeMapFormat.cs
+++ b/Sledge.Formats.Map/Formats/QuakeMapFormat.cs
@@ -223,7 +223,7 @@ namespace Sledge.Formats.Map.Formats
             {
                 while (it.Current?.Is(TokenType.Whitespace) == false)
                 {
-                    face.TextureName = it.Current.Value;
+                    face.TextureName += it.Current.Value;
                     it.MoveNext();
                 }
                 Expect(it, TokenType.Whitespace, " ");


### PR DESCRIPTION
Certain characters (some brief testing suggests it's just `{` and `}`) can cause texture names to be split into multiple tokens. Currently the parser only keeps the final token, these should be concatenated.