### PR TITLE
Make midmap count public

### DIFF
--- a/Sledge.Formats.Texture/Vtf/VtfFile.cs
+++ b/Sledge.Formats.Texture/Vtf/VtfFile.cs
@@ -48,7 +48,7 @@ namespace Sledge.Formats.Texture.Vtf
                 Header.BumpmapScale = br.ReadSingle();
 
                 var highResImageFormat = (VtfImageFormat) br.ReadUInt32();
-                var mipmapCount = br.ReadByte();
+                Header.MipmapCount = br.ReadByte();
                 var lowResImageFormat = (VtfImageFormat) br.ReadUInt32();
                 var lowResWidth = br.ReadByte();
                 var lowResHeight = br.ReadByte();
@@ -128,7 +128,7 @@ namespace Sledge.Formats.Texture.Vtf
                 }
 
                 br.BaseStream.Position = dataPos;
-                for (var mip = mipmapCount - 1; mip >= 0; mip--)
+                for (var mip = Header.MipmapCount - 1; mip >= 0; mip--)
                 {
                     for (var frame = 0; frame < numFrames; frame++)
                     {

--- a/Sledge.Formats.Texture/Vtf/VtfHeader.cs
+++ b/Sledge.Formats.Texture/Vtf/VtfHeader.cs
@@ -8,5 +8,6 @@ namespace Sledge.Formats.Texture.Vtf
         public VtfImageFlag Flags { get; set; }
         public Vector3 Reflectivity { get; set; }
         public float BumpmapScale { get; set; }
+        public byte MipmapCount { get; set; }
     }
 }


### PR DESCRIPTION
Expose the vtf mipmap count as public variable.
This can be useful for extracting individual frames from the vtf.